### PR TITLE
jwt amb access token

### DIFF
--- a/app/screens/Login.tsx
+++ b/app/screens/Login.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList, screenProps } from "../navigation/screenType";
 import { useState, useCallback } from "react";
+import * as SecureStore from "expo-secure-store";
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, "Login">;
 
@@ -26,11 +27,17 @@ export const Login = () => {
         Alert.alert("Error", "Por favor, completa todos los campos.");
         return;
       }
+
+      const secureStoreAvailable = await SecureStore.isAvailableAsync();
   
       try {
         const response = await fetch("http://localhost:9000/api/login", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...( secureStoreAvailable ? {"x-client": "mobile"} : {}),
+          },
+
           body: JSON.stringify({ email, password }),
         });
   
@@ -41,6 +48,11 @@ export const Login = () => {
           window.alert("Éxito en el inicio de sesión ✅");
           console.log("Éxito en el inicio de sesión ✅");
           Alert.alert("Éxito", "Inicio de sesión correcto ✅");
+          if (secureStoreAvailable) {
+            SecureStore.setItem("accessToken", data.accessToken);
+          } else {
+            localStorage.setItem("accessToken", data.accessToken);
+          }
           navigation.navigate("Home");
         } else {
           window.alert("Error. Inicio de sesión fallido ❌");

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-haptics": "~14.0.1",
         "expo-linking": "~7.0.5",
         "expo-router": "~4.0.19",
+        "expo-secure-store": "^14.0.1",
         "expo-splash-screen": "~0.29.22",
         "expo-status-bar": "~2.0.1",
         "expo-symbols": "~0.2.2",
@@ -6959,6 +6960,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
+      "integrity": "sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-haptics": "~14.0.1",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.19",
+    "expo-secure-store": "^14.0.1",
     "expo-splash-screen": "~0.29.22",
     "expo-status-bar": "~2.0.1",
     "expo-symbols": "~0.2.2",


### PR DESCRIPTION
Añadir autenticación en socket.io con token JWT. Se usa un access token que se guarda en almacenamiento local y se obtiene en el login. Cuando caduca e intentamos usar el websocket, nos redirige a login.

Sería interesante añadir también un refresh token.